### PR TITLE
Update inifile compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.13.1 <6.0.0" },
-    { "name": "puppetlabs/inifile", "version_requirement": ">= 1.0.0 <3.0.0" },
+    { "name": "puppetlabs/inifile", "version_requirement": ">= 1.0.0 <4.0.0" },
     { "name": "herculesteam/augeasproviders_shellvar", "version_requirement": ">= 2.0.0 <4.0.0" }
   ],
   "requirements": [


### PR DESCRIPTION
Update puppet module inifile compatibility to versions under 4.0.0.

With the latest version of inifile on yum_cron 4.1.0, ```puppet module list --tree```
resulted in:

    Warning: Module 'puppetlabs-inifile' (v3.0.0) fails to meet some dependencies:
      'treydock-yum_cron' (v4.1.0) requires 'puppetlabs-inifile' (>= 1.0.0 <3.0.0)