### PR TITLE
RHEL8 Support (for dnf-automatic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 
 ## Overview
 
-The yum_cron module manages the *yum-cron* package to allow for automatic updates and available updates notifications.
+The yum_cron module manages either the *yum-cron* or *dnf-automatic* (RHEL/CentOS 8+) package to allow for automatic updates
+and available updates notifications.
 
 ## Backwards Compatibility
 
@@ -32,6 +33,8 @@ Version 1.x of this module replaced the **disable_yum_autoupdate** and **remove_
 ### Class: yum_cron
 
 The default parameters will install and enable yum-cron to only check for updates and notify root if any are available.
+Generally, dnf-automatic uses different paths, but functions very similarly and has a similar config file.  For the rest
+of the documentation, you can generally assuming that references to yum-cron also apply to dnf-automatic.
 
 **On Scientific Linux the default behavior is also to disable *yum-autoupdate*.**
 
@@ -39,9 +42,9 @@ The default parameters will install and enable yum-cron to only check for update
 
 These are the actions taken by the module with default parameter values:
 
-* Install yum-cron
+* Install yum-cron/dnf-automatic
 * Set configuration values to enable checking for updates and notify root
-* Start and enable the yum-cron service
+* Start and enable the yum-cron/dnf-automatic service
 * Disable yum-autoupdate by setting ENABLED="false" in /etc/sysconfig/yum-autoupdate **(Scientific Linux only)**
 
 This is an example of enabling automatic updates
@@ -80,7 +83,8 @@ This module should be compatible with all RedHat based operating systems and Pup
 
 It has only been tested on:
 
-* CentOS 7
+* RHEL/CentOS 8
+* RHEL/CentOS 7
 * CentOS 6
 * Scientific Linux 6
 

--- a/lib/puppet/provider/dnf_automatic_config/ini_setting.rb
+++ b/lib/puppet/provider/dnf_automatic_config/ini_setting.rb
@@ -1,0 +1,22 @@
+Puppet::Type.type(:dnf_automatic_config).provide(
+  :ini_setting,
+  parent: Puppet::Type.type(:ini_setting).provider(:ruby),
+) do
+  desc 'dnf_automatic_config provider'
+
+  def section
+    resource[:name].split('/', 2).first
+  end
+
+  def setting
+    resource[:name].split('/', 2).last
+  end
+
+  def separator
+    ' = '
+  end
+
+  def self.file_path
+    '/etc/dnf/automatic.conf'
+  end
+end

--- a/lib/puppet/type/dnf_automatic_config.rb
+++ b/lib/puppet/type/dnf_automatic_config.rb
@@ -1,0 +1,36 @@
+Puppet::Type.newtype(:dnf_automatic_config) do
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'Section/setting name to manage from dnf-automatic.conf'
+    # namevar should be of the form section/setting
+    validate do |value|
+      unless value =~ %r{\S+/\S+}
+        raise("Invalid dnf_automatic_config #{value}, entries should be in the form of section/setting.")
+      end
+    end
+  end
+
+  newproperty(:value) do
+    desc 'The value of the setting to be defined.'
+    munge do |v|
+      v.to_s.strip
+    end
+  end
+
+  validate do
+    if self[:ensure] == :present
+      if self[:value].nil?
+        raise Puppet::Error, "Property value must be set for #{self[:name]} when ensure is present"
+      end
+    end
+  end
+
+  autorequire(:file) do
+    ['/etc/dnf/automatic.conf']
+  end
+
+  autorequire(:package) do
+    ['dnf-automatic']
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,25 @@ class yum_cron::config {
   }
 
   if $yum_cron::ensure == 'present' {
-    if $::operatingsystemmajrelease >= '7' {
+    if $::operatingsystemmajrelease == '8' {
+      Dnf_automatic_config {
+        notify => $yum_cron::config_notify,
+      }
+
+      dnf_automatic_config { 'commands/update_cmd': value => $yum_cron::update_cmd }
+      dnf_automatic_config { 'commands/update_messages': value => $yum_cron::update_messages }
+      dnf_automatic_config { 'commands/download_updates': value => $yum_cron::download_updates_str }
+      dnf_automatic_config { 'commands/apply_updates': value => $yum_cron::apply_updates_str }
+      dnf_automatic_config { 'commands/random_sleep': value => $yum_cron::randomwait }
+      dnf_automatic_config { 'emitters/system_name': value => $yum_cron::systemname }
+      dnf_automatic_config { 'email/email_to': value => $yum_cron::mailto }
+      dnf_automatic_config { 'email/email_host': value => $yum_cron::email_host }
+      dnf_automatic_config { 'base/debuglevel': value => $yum_cron::debug_level }
+
+      create_resources(dnf_automatic_config, $yum_cron::extra_configs)
+    }
+
+    if $::operatingsystemmajrelease == '7' {
       Yum_cron_config {
         notify => $yum_cron::config_notify,
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,18 +4,27 @@ class yum_cron::params {
 
   case $::osfamily {
     'RedHat': {
-      $package_name       = 'yum-cron'
-      $service_name       = 'yum-cron'
       $service_hasstatus  = true
       $service_hasrestart = true
 
       case $::operatingsystemmajrelease {
+        '8': {
+          $package_name     = 'dnf-automatic'
+          $service_name     = 'dnf-automatic.timer'
+          $config_path      = '/etc/dnf/automatic.conf'
+          $debug_level      = '-2'
+          $randomwait       = '360'
+        }
         '7': {
+          $package_name     = 'yum-cron'
+          $service_name     = 'yum-cron'
           $config_path      = '/etc/yum/yum-cron.conf'
           $debug_level      = '-2'
           $randomwait       = '360'
         }
         '6': {
+          $package_name     = 'yum-cron'
+          $service_name     = 'yum-cron'
           $config_path      = '/etc/sysconfig/yum-cron'
           $debug_level      = '0'
           $randomwait       = '60'

--- a/metadata.json
+++ b/metadata.json
@@ -26,14 +26,16 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {


### PR DESCRIPTION
Howdy!  This PR adds support for RHEL8 by adding support for DNF.  I originally was thinking about doing a separate module for dnf-automatic, but it's so similar to yum-cron and also is really just Yum 4 that it seemed like it made more sense to keep it here.

Now -- I'm submitting the PR to start a conversation atm.  I haven't added any testing or documentation components yet.  Could you please take a look and let me know what you think and if you are happy with this solution I'll polish things up?  Thanks!

This is in reference to #21 