### PR TITLE
Add support for CentOS 9

### DIFF
--- a/data/version/9.yaml
+++ b/data/version/9.yaml
@@ -1,0 +1,3 @@
+yum_cron::package_name: dnf-automatic
+yum_cron::service_name: dnf-automatic.timer
+yum_cron::config_path: /etc/dnf/automatic.conf


### PR DESCRIPTION
Just tested on my new CentOS 9 machine, creating this file in my local version of the package created the proper DNF automatic timers on my machine.

```
Info: Applying configuration version '1655264672'
Notice: /Stage[main]/Yum_cron::Install/Package[yum-cron]/ensure: created
Notice: /Stage[main]/Yum_cron::Service/Service[yum-cron]/ensure: ensure changed 'stopped' to 'running'

[root@XXXXXXXX ~]# systemctl status dnf-automatic.timer
● dnf-automatic.timer - dnf-automatic timer
     Loaded: loaded (/usr/lib/systemd/system/dnf-automatic.timer; enabled; vendor preset: disabled)
     Active: active (waiting) since Wed 2022-06-15 13:44:36 AEST; 10s ago
      Until: Wed 2022-06-15 13:44:36 AEST; 10s ago
    Trigger: Thu 2022-06-16 06:53:05 AEST; 17h left
   Triggers: ● dnf-automatic.service
   
[root@XXXXXXXXX ~]# cat /etc/os-release
NAME="CentOS Stream"
VERSION="9"
ID="centos"
ID_LIKE="rhel fedora"
```