### PR TITLE
Introduce "mail_from" and "emit_via" as configurable settings

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -127,6 +127,14 @@ Sets random wait time.
 
 Default value: `'360'`
 
+##### <a name="-yum_cron--mailfrom"></a>`mailto`
+
+Data type: `String`
+
+Sender address to use.
+
+Default value: `'root@example.com'`
+
 ##### <a name="-yum_cron--mailto"></a>`mailto`
 
 Data type: `String`
@@ -142,6 +150,14 @@ Data type: `String`
 Name of system used in notifications.
 
 Default value: `$facts['networking']['fqdn']`
+
+##### <a name="-yum_cron--emit_via"></a>`mailto`
+
+Data type: `String`
+
+How to send messages.
+
+Default value: `'stdio'`
 
 ##### <a name="-yum_cron--email_host"></a>`email_host`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,6 +17,8 @@ class yum_cron::config {
       yum_cron_config { 'commands/apply_updates': value => $yum_cron::apply_updates_str }
       yum_cron_config { 'commands/random_sleep': value => $yum_cron::randomwait }
       yum_cron_config { 'emitters/system_name': value => $yum_cron::systemname }
+      yum_cron_config { 'emitters/emit_via': value => $yum_cron::emit_via }
+      yum_cron_config { 'email/email_from': value => $yum_cron::mailfrom }
       yum_cron_config { 'email/email_to': value => $yum_cron::mailto }
       yum_cron_config { 'email/email_host': value => $yum_cron::email_host }
       yum_cron_config { 'base/debuglevel': value => $yum_cron::debug_level }
@@ -44,6 +46,8 @@ class yum_cron::config {
       dnf_automatic_config { 'commands/apply_updates': value => $yum_cron::apply_updates_str }
       dnf_automatic_config { 'commands/random_sleep': value => $yum_cron::randomwait }
       dnf_automatic_config { 'emitters/system_name': value => $yum_cron::systemname }
+      dnf_automatic_config { 'emitters/emit_via': value => $yum_cron::emit_via }
+      dnf_automatic_config { 'email/email_from': value => $yum_cron::mailfrom }
       dnf_automatic_config { 'email/email_to': value => $yum_cron::mailto }
       dnf_automatic_config { 'email/email_host': value => $yum_cron::email_host }
       dnf_automatic_config { 'base/debuglevel': value => $yum_cron::debug_level }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,8 +89,10 @@ class yum_cron (
   Pattern[/^(?:-)?[0-9]$/] $debug_level = '-2',
   Pattern[/^[0-9]+$/] $randomwait = '360',
   Array $exclude_packages = [],
+  String $mailfrom = 'root@example.com',
   String $mailto = 'root',
   String $systemname = $facts['networking']['fqdn'],
+  String $emit_via = 'stdio',
   String $email_host = 'localhost',
   # EL7 only options
   Yum_cron::Update_cmd $update_cmd = 'default',


### PR DESCRIPTION
This will introduce the emitter setting "emit_via" and the mail related "mail_from" setting to define a sender address.