### PR TITLE
feat(reboot): add reboot and reboot_command configuration options for dnf-automatic service

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -41,6 +41,8 @@ The following parameters are available in the `yum_cron` class:
 * [`download_updates`](#-yum_cron--download_updates)
 * [`apply_updates`](#-yum_cron--apply_updates)
 * [`upgrade_type`](#-yum_cron--upgrade_type)
+* [`reboot`](#-yum_cron--reboot)
+* [`reboot_command`](#-yum_cron--reboot_command)
 * [`debug_level`](#-yum_cron--debug_level)
 * [`exclude_packages`](#-yum_cron--exclude_packages)
 * [`randomwait`](#-yum_cron--randomwait)
@@ -102,6 +104,24 @@ The kind of updates to perform.
 Applies only to EL8, EL9.
 
 Default value: `'default'`
+
+##### <a name="-yum_cron--reboot"></a>`reboot`
+
+Data type: `Enum['never','when-changed','when-needed']`
+
+When the system should reboot following upgrades.
+Applies only to EL8, EL9.
+
+Default value: `'never'`
+
+##### <a name="-yum_cron--reboot_command"></a>`reboot_command`
+
+Data type: `String`
+
+Specify the command to run to trigger a reboot of the system.
+Applies only to EL8, EL9.
+
+Default value: `"shutdown -r +5 'Rebooting after applying package updates'"`
 
 ##### <a name="-yum_cron--debug_level"></a>`debug_level`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,7 +44,7 @@ class yum_cron::config {
       dnf_automatic_config { 'commands/apply_updates': value => $yum_cron::apply_updates_str }
       dnf_automatic_config { 'commands/random_sleep': value => $yum_cron::randomwait }
       dnf_automatic_config { 'commands/reboot': value => $yum_cron::reboot }
-      dnf_automatic_config { 'commands/reboot_command': value => $yum_cron::reboot_command }
+      dnf_automatic_config { 'commands/reboot_command': value => "\"${yum_cron::reboot_command}\"" }
       dnf_automatic_config { 'emitters/system_name': value => $yum_cron::systemname }
       dnf_automatic_config { 'email/email_to': value => $yum_cron::mailto }
       dnf_automatic_config { 'email/email_host': value => $yum_cron::email_host }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -43,6 +43,8 @@ class yum_cron::config {
       dnf_automatic_config { 'commands/download_updates': value => $yum_cron::download_updates_str }
       dnf_automatic_config { 'commands/apply_updates': value => $yum_cron::apply_updates_str }
       dnf_automatic_config { 'commands/random_sleep': value => $yum_cron::randomwait }
+      dnf_automatic_config { 'commands/reboot': value => $yum_cron::reboot }
+      dnf_automatic_config { 'commands/reboot_command': value => $yum_cron::reboot_command }
       dnf_automatic_config { 'emitters/system_name': value => $yum_cron::systemname }
       dnf_automatic_config { 'email/email_to': value => $yum_cron::mailto }
       dnf_automatic_config { 'email/email_host': value => $yum_cron::email_host }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,17 @@
 # @param upgrade_type
 #   The kind of updates to perform.
 #   Applies only to EL8, EL9.
+# @param reboot
+#   Determines when the system should reboot.
+#   Valid values:
+#   * 'never' (default) - does not reboot the system
+#   * 'when-changed'    - triggers a reboot after any upgrade
+#   * 'when-needed'     - triggers a reboot only when rebooting is necessary to apply changes
+#   Applies only to EL8 and EL9.
+# @param reboot_command
+#   Command to execute for rebooting the system after applying updates.
+#   Default is "shutdown -r +5 'Rebooting after applying package updates'".
+#   Applies only to EL8 and EL9.
 # @param debug_level
 #   Sets debug level.
 # @param exclude_packages
@@ -83,8 +94,10 @@ class yum_cron (
   Boolean $enable = true,
   Boolean $download_updates = true,
   Boolean $apply_updates = false,
-  # EL8 only options
+  # EL8 and EL9 only options
   Enum['default','security'] $upgrade_type = 'default',
+  Enum['never','when-changed','when-needed'] $reboot = 'never',
+  String $reboot_command = "\"shutdown -r +5 'Rebooting after applying package updates'\"",
   # EL8 and EL7 options
   Pattern[/^(?:-)?[0-9]$/] $debug_level = '-2',
   Pattern[/^[0-9]+$/] $randomwait = '360',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,7 +97,7 @@ class yum_cron (
   # EL8 and EL9 only options
   Enum['default','security'] $upgrade_type = 'default',
   Enum['never','when-changed','when-needed'] $reboot = 'never',
-  String $reboot_command = "\"shutdown -r +5 'Rebooting after applying package updates'\"",
+  String $reboot_command = "shutdown -r +5 'Rebooting after applying package updates'",
   # EL8 and EL7 options
   Pattern[/^(?:-)?[0-9]$/] $debug_level = '-2',
   Pattern[/^[0-9]+$/] $randomwait = '360',


### PR DESCRIPTION
This pull request introduces new configuration options for the dnf-automatic service, specifically adding support for `reboot` and `reboot_command` parameters. These enhancements allow for more granular control over system reboots following updates managed by dnf-automatic.