### PR TITLE
fix(dnf): use excludepkgs instead of exclude for DNF automatic

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,7 +49,8 @@ class yum_cron::config {
       dnf_automatic_config { 'email/email_to': value => $yum_cron::mailto }
       dnf_automatic_config { 'email/email_host': value => $yum_cron::email_host }
       dnf_automatic_config { 'base/debuglevel': value => $yum_cron::debug_level }
-      dnf_automatic_config { 'base/exclude':
+      dnf_automatic_config { 'base/exclude': ensure => 'absent' }
+      dnf_automatic_config { 'base/excludepkgs':
         ensure => $yum_cron::exclude_packages_ensure,
         value  => join($yum_cron::exclude_packages, ' '),
       }


### PR DESCRIPTION
## Summary

DNF automatic requires `excludepkgs` in the `[base]` section, not `exclude`. The `exclude` parameter is silently ignored by DNF.

## Changes

- Changed `base/exclude` to `base/excludepkgs` in the DNF automatic config section
- Added `base/exclude` with `ensure => 'absent'` to clean up any existing incorrect entries

## References

- Fixes #52
- DNF docs: https://dnf.readthedocs.io/en/latest/conf_ref.html
