### PR TITLE
Fix dnf_automatic_config writing values as arrays

### DIFF
--- a/lib/puppet/type/dnf_automatic_config.rb
+++ b/lib/puppet/type/dnf_automatic_config.rb
@@ -13,15 +13,16 @@ Puppet::Type.newtype(:dnf_automatic_config) do
     end
   end
 
-  newproperty(:value, array_matching: :all) do
+  newproperty(:value) do
     desc 'The value of the setting to be defined.'
     munge do |v|
       v.to_s.strip
     end
 
-    def should_to_s(newvalue)
-      newvalue = newvalue.first if newvalue.is_a?(Array) && newvalue.length == 1
-      newvalue
+    def insync?(is)
+      # inifile >= 6.4.1 may return the current value wrapped in an array
+      is = is.first if is.is_a?(Array)
+      is == should
     end
   end
 


### PR DESCRIPTION
## Summary

Remove `array_matching: :all` from the `value` property in `dnf_automatic_config` type.

Newer versions of `puppetlabs/inifile` (>=6.x) write array values with bracket notation, resulting in invalid configuration:

```ini
upgrade_type = ["default"]
random_sleep = ["360"]
download_updates = ["yes"]
